### PR TITLE
Fix updater endpoint URL in Tauri config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRCNDA0QkM5ODAwNzhDNUUKUldSZWpBZUF5VXRBU3lMaUs4cVNuY2JRdURTdHhsOVY2ZHdiZWN5cWdDeUl1RzB1SzJsZXJXL0sK",
       "endpoints": [
-        "https://github.com/Tsugumik/shinden-client/repo/releases/latest/download/latest.json"
+        "https://github.com/Tsugumik/shinden-client/releases/latest/download/latest.json"
       ]
     }
   }


### PR DESCRIPTION
Corrected the updater endpoint URL in tauri.conf.json by removing the erroneous '/repo' segment. This ensures the application checks the correct GitHub releases path for updates.