### PR TITLE
Fix undefined in console while searching anime

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ShindenClient"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cda-dl",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ShindenClient"
-version = "4.0.0"
+version = "4.0.1"
 description = "A Tauri App"
 authors = ["Błażej Drozd"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Shinden Client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "identifier": "com.blazejdrozd.shinden-client-rs",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import {page} from "$app/state";
     import {invoke} from "@tauri-apps/api/core";
     import {onMount} from "svelte";
     import type {Anime} from "$lib/types";
@@ -13,7 +12,7 @@
 
     onMount(async () => {
         try {
-            log(LogLevel.INFO, `Searching anime: ${page.params.name}`);
+            log(LogLevel.INFO, `Searching anime: ${params.animeName}`);
 
             result = await invoke("search", {
                 query: params.animeName
@@ -27,15 +26,15 @@
                     return b_rating - a_rating;
                 });
                 globalStates.loadingState = LoadingState.OK;
-                log(LogLevel.SUCCESS, `Searching anime: ${page.params.name} done`);
+                log(LogLevel.SUCCESS, `Searching anime: ${params.animeName} done`);
             } else {
 
-                log(LogLevel.WARNING, `Searching anime: ${page.params.name} found 0 results`);
+                log(LogLevel.WARNING, `Searching anime: ${params.animeName} found 0 results`);
                 globalStates.loadingState = LoadingState.WARNING;
             }
         } catch (e) {
             globalStates.loadingState = LoadingState.ERROR;
-            log(LogLevel.ERROR, `Error searching anime: ${page.params.name}`);
+            log(LogLevel.ERROR, `Error searching anime: ${params.animeName}`);
         }
     })
 


### PR DESCRIPTION
Replaces usage of page.params.name (undefined) with params.animeName in search logging
Before
<img width="870" height="144" alt="image" src="https://github.com/user-attachments/assets/770fb901-c245-427a-b821-2d6dc1cb56a6" />
After
<img width="874" height="134" alt="image" src="https://github.com/user-attachments/assets/8284352c-4029-4465-80e7-7701fbea6f8e" />
